### PR TITLE
READY: Allow empty traffic in exclusivesplit

### DIFF
--- a/lib/builds-user-config.coffee
+++ b/lib/builds-user-config.coffee
@@ -15,7 +15,8 @@ module.exports = class BuildsUserConfig
       if config.features?
         if config.exclusiveSplit
           pick = @exclusiveSplit(config.features, base, config.unsticky)
-          userConfig[pick] = @build(config.features[pick], base[pick], true)
+          if pick
+            userConfig[pick] = @build(config.features[pick], base[pick], true)
         else
           _(config.features).each (feature, name) =>
             userConfig[name] = @build(feature, base[name])
@@ -30,9 +31,10 @@ module.exports = class BuildsUserConfig
     winner = null
     r = @math.random()
     _(features).each (feature, name) ->
-      ceiling = floor + feature.traffic
-      winner = name if floor <= r && ceiling > r
-      floor = ceiling
+      if feature.traffic?
+        ceiling = floor + feature.traffic
+        winner = name if floor <= r && ceiling > r
+        floor = ceiling
     return winner
 
   validSplitKeys: (base) ->

--- a/spec/feature-toggle-spec.coffee
+++ b/spec/feature-toggle-spec.coffee
@@ -314,6 +314,27 @@ describe "FeatureToggle", ->
       Then ->
         @req.ftoggle.findEnabledChildren()[0] == 'b'
 
+    context "no traffic set, no winner", ->
+      Given -> @subject.setConfig
+        exclusiveSplit: true
+        features:
+          a: {}
+          b: {}
+      Then ->
+        @req.ftoggle.findEnabledChildren().length == 0
+
+    context "mixed traffic and no traffic", ->
+      Given -> @subject.setConfig
+        exclusiveSplit: true
+        features:
+          a:
+            traffic: 0.2
+          b:
+            traffic: 0.8
+          c: {}
+      Then ->
+        @req.ftoggle.findEnabledChildren()[0] == 'b'
+
   describe "middleware sets cookie", ->
     Given -> @subject.setConfig
       name: "foo"


### PR DESCRIPTION
Previous behavior was not formally defined, and behaved oddly.
