### PR TITLE
READY: handle out of date cookie caused by bookmarked links that toggle stuff on

### DIFF
--- a/lib/builds-user-config.coffee
+++ b/lib/builds-user-config.coffee
@@ -6,35 +6,47 @@ module.exports = class BuildsUserConfig
 
   build: (config, cookie = {}, pass = false) ->
     _({}).tap (userConfig) =>
-      alreadySet = cookie.enabled? and not config.unsticky
-      if alreadySet
-        userConfig.enabled = cookie.enabled
-      else
-        userConfig.enabled = (if config.traffic? then @math.random() <= config.traffic else true)
-        userConfig.enabled = true if pass
-
-      userConfig.version = config.version if config.version?
-      if config.features? and userConfig.enabled
-        if config.exclusiveSplit
-          if not alreadySet
-            # need to pick the exclusive split winner
-            pick = @exclusiveSplit(config.features, cookie, config.unsticky)
-            if pick
-              userConfig[pick] = @build(config.features[pick], cookie[pick], true)
-          else
-            # we already picked a winner, loop through features to find only that one and (re)build it
-            _(@validSplitKeys(cookie)).each (name) =>
-              if (cookie[name].enabled)
-                userConfig[name] = @build(config.features[name], cookie[name])
+      if config?
+        alreadySet = cookie.enabled? and not config.unsticky
+        if alreadySet
+          userConfig.enabled = cookie.enabled
         else
-          _(config.features).each (feature, name) =>
-            userConfig[name] = @build(feature, cookie[name])
+          userConfig.enabled = (if config.traffic? then @math.random() <= config.traffic else true)
+          userConfig.enabled = true if pass
+
+        userConfig.version = config.version if config.version?
+        if config.features? and userConfig.enabled
+          if config.exclusiveSplit
+            if not alreadySet
+              # need to pick the exclusive split winner
+              pick = @exclusiveSplit(config.features, cookie, config.unsticky)
+              if pick
+                userConfig[pick] = @build(config.features[pick], cookie[pick], true)
+            else
+              # we already picked a winner, loop through features to find only that one and (re)build it
+              rebuilt = false
+              _(@validSplitKeys(cookie)).each (name) =>
+                if (cookie[name].enabled and config.features[name]?)
+                  rebuilt = true
+                  userConfig[name] = @build(config.features[name], cookie[name])
+
+              if (!rebuilt)
+                # cookie did not have a valid winner set, so re-pick the winner
+                pick = @exclusiveSplit(config.features, cookie, config.unsticky)
+                if pick
+                  userConfig[pick] = @build(config.features[pick], cookie[pick], true)
+          else
+            _(config.features).each (feature, name) =>
+              userConfig[name] = @build(feature, cookie[name])
 
   # private
 
   exclusiveSplit: (features, cookie, unsticky) ->
     if not unsticky and @validSplitKeys(cookie).length > 0
-      return @validSplitKeys(cookie)[0]
+      cookieWinner = @validSplitKeys(cookie)[0]
+      # make sure the value from the cookie exists in the config
+      if features[cookieWinner]?
+        return @validSplitKeys(cookie)[0]
 
     floor = 0
     winner = null

--- a/spec/feature-toggle-spec.coffee
+++ b/spec/feature-toggle-spec.coffee
@@ -222,6 +222,43 @@ describe "FeatureToggle", ->
       Then -> @req.ftoggle.isFeatureEnabled('nestedtest.baz') == true
       And -> @req.ftoggle.isFeatureEnabled('nestedtest.bar') == false
 
+    context "old cookie with no longer valid split choice (can happen via query param override from bookmark)", ->
+      Given -> @subject.setConfig
+        version: 1
+        name: "foo"
+        features:
+          nestedtest:
+            traffic: 1
+            exclusiveSplit: true
+            features:
+              bar:
+                exclusiveSplit: true
+                traffic: 0.5
+                features:
+                  quux:
+                    traffic: 0.5
+                  bazinga:
+                    traffic: 0.5
+              baz:
+                exclusiveSplit: true
+                traffic: 0.5
+                features:
+                  wonderful:
+                    traffic: 0.5
+                  lovely:
+                    traffic: 0.5
+      Given -> @req.cookies['ftoggle-foo'] =
+        version: 1
+        enabled: true
+        nestedtest:
+          enabled: true
+          bam:
+            enabled: true
+            wonderful:
+              enabled: true
+      Then -> @req.ftoggle.isFeatureEnabled('nestedtest.bam') == false
+      And -> (@req.ftoggle.isFeatureEnabled('nestedtest.bar') || @req.ftoggle.isFeatureEnabled('nestedtest.bar')) == true
+
 
     context "cookie with unsticky exclusiveSplit", ->
       Given -> @subject.setConfig


### PR DESCRIPTION
handle when a cookie value exists that doesn't match an existing feature...happens when somebody bookmarks a link that manually turns on an ftoggle feature (such as google experiments)

@johndorn 
