### PR TITLE
READY: Remove usage of deprecated function

### DIFF
--- a/lib/feature-toggle.coffee
+++ b/lib/feature-toggle.coffee
@@ -39,8 +39,8 @@ module.exports = class FeatureToggle
 
   overrideByQueryParam: (userConfig, req) ->
     new OverridesToggleConfig(@toggleConfig, userConfig).
-      override(req.param("#{@toggleName()}-on"), true).
-      override(req.param("#{@toggleName()}-off"), false)
+      override(req.query["#{@toggleName()}-on"], true).
+      override(req.query["#{@toggleName()}-off"], false)
 
   overrideByHeader: (userConfig, req) ->
     new OverridesToggleConfig(@toggleConfig, userConfig).


### PR DESCRIPTION
@faktorsmak @reprehensible @FabledWeb - Upgrade manta-frontend version of express to 4.12.x, which deprecates `req.param()`, so changing the two references here to `req.query` (which is where these params would be anyway). If we think we want to be able to pass them in the body too, we could make an allowance for that, but it feels like we've decided just to always use query params.
