### PR TITLE
READY: Try catch cookie parsing, since old style is incompatible

### DIFF
--- a/lib/feature-toggle.coffee
+++ b/lib/feature-toggle.coffee
@@ -18,7 +18,11 @@ module.exports = class FeatureToggle
     (req, res, next) =>
       defaults = @getDefaults(req)
       cookie = req.cookies[@toggleName()] or '{}'
-      userConfig = @createUserConfig(JSON.parse(cookie), if parseInt(req.headers["x-bot"]) then true else false)
+      try
+        cookie = JSON.parse(cookie)
+      catch e
+        cookie = {}
+      userConfig = @createUserConfig(cookie, if parseInt(req.headers["x-bot"]) then true else false)
       @overrideByHeader(userConfig, req)
       @overrideByQueryParam(userConfig, req)
       featureVals = @createFeatureVals(userConfig)

--- a/spec/feature-toggle-spec.coffee
+++ b/spec/feature-toggle-spec.coffee
@@ -111,6 +111,16 @@ describe "FeatureToggle", ->
       Given -> @req.cookies['ftoggle-foo'] = JSON.stringify({e: 1, v: 1})
       Then -> @req.ftoggle.isFeatureEnabled('foo') == false
 
+    context 'old style cookie previously set', ->
+      Given -> @subject.setConfig
+        name: "foo"
+        version: 1
+        features:
+         foo:
+           traffic: 1
+      Given -> @req.cookies['ftoggle-foo'] = {e: 1, v: 1}
+      Then -> @req.ftoggle.isFeatureEnabled('foo') == true
+
     context "cookie previously set with old version", ->
       Given -> @subject.setConfig
         version: 3


### PR DESCRIPTION
@faktorsmak @reprehensible - Discovered this when pulling the last version into manta frontend. Express _helpfully_ parses json into real objects, so `JSON.parse` fails for existing ftoggle cookies.
